### PR TITLE
chore: remove reflections version restriction

### DIFF
--- a/default.json
+++ b/default.json
@@ -19,11 +19,6 @@
       "allowedVersions": "/^[0-9]+\\.[0-9]+\\.[0-9]+?$/"
     },
     {
-      "groupName": "Reflections",
-      "matchPackageNames": ["org.reflections:reflections"],
-      "allowedVersions": "<=0.9.11"
-    },
-    {
       "matchUpdateTypes": ["patch", "pin", "digest"],
       "automerge": true
     }


### PR DESCRIPTION
The Reflections library was already updated to 0.10.2, the issue that necessitated this restriction appears to be fixed.